### PR TITLE
Update mod.cx_disqus.php

### DIFF
--- a/system/expressionengine/third_party/cx_disqus/mod.cx_disqus.php
+++ b/system/expressionengine/third_party/cx_disqus/mod.cx_disqus.php
@@ -69,9 +69,9 @@ EOT;
 
 		$out .= '
 <script type="text/javascript">
-	var disqus_shortname = '.$this->EE->javascript->generate_json($forum).';
-	var disqus_identifier = '.$this->EE->javascript->generate_json($entry_id).';
-	var disqus_title = '.$this->EE->javascript->generate_json($title).';';
+	var disqus_shortname = '.json_encode($forum).';
+	var disqus_identifier = '.json_encode((string)$entry_id).';
+	var disqus_title = '.json_encode($title).';';
 
 		if ($dev_mode == 'yes')
 		{


### PR DESCRIPTION
EE 2.6 deprecated generate_json() and wants to use the native json_encode() instead.

Replaced $this->EE->javascript->generate_json() with json_encode() on lines 72-74. Also, converted $entry_id to a string for json_encode(). While most probably leave it as the actual entry_id integer, Disqus does accept any string.
