### PR TITLE
Update mcp.cx_disqus for ExpressionEngine 2.8

### DIFF
--- a/system/expressionengine/third_party/cx_disqus/mcp.cx_disqus.php
+++ b/system/expressionengine/third_party/cx_disqus/mcp.cx_disqus.php
@@ -30,7 +30,7 @@ class Cx_disqus_mcp {
 
 	public function index()
 	{
-		$this->EE->cp->set_variable('cp_page_title', lang('cx_disqus'));
+		$this->EE->view->cp_page_title = 'cx_disqus';
 
 		$data = array(
 			'post_url' => CX_DISQUS_CP,


### PR DESCRIPTION
Cp::set_variable($name, $value)
Deprecated since version 2.6: Use $this->EE->view->cp_page_title = '...' instead.

http://ellislab.com/expressionengine/user-guide/development/usage/cp.html#set-variables
